### PR TITLE
disable steps that don't work on a fork on PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,6 +45,8 @@ jobs:
     - name: What
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Docker Login LCAS
+      # don't attempt to login for PRs
+      if: ${{ github.event_name != 'pull_request' }} 
       # You may pin to the exact commit or the version.
       # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       uses: docker/login-action@v2
@@ -56,6 +58,8 @@ jobs:
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
     - name: Docker Login dockerhub
+      # don't attempt to login for PRs
+      if: ${{ github.event_name != 'pull_request' }} 
       uses: docker/login-action@v2
       with:
         # Username used to log against the Docker registry


### PR DESCRIPTION
In response to the error in [#7 ](https://github.com/LCAS/limo_ros2/pull/7#issuecomment-1821593162) this disables the logging in for PRs.