### PR TITLE
change colour space from RGB8 to the expected BGR8

### DIFF
--- a/src/limo_description/urdf/limo_four_diff.gazebo
+++ b/src/limo_description/urdf/limo_four_diff.gazebo
@@ -199,7 +199,7 @@
                 <image>
                     <width>640</width>
                     <height>480</height>
-                    <format>R8G8B8</format>
+                    <format>B8G8R8</format>
                 </image>
             </camera>
 

--- a/src/limo_description/urdf/limo_gazebo.gazebo
+++ b/src/limo_description/urdf/limo_gazebo.gazebo
@@ -77,7 +77,7 @@
               <image>
                   <width>640</width>
                   <height>480</height>
-                  <format>R8G8B8</format>
+                  <format>B8G8R8</format>
               </image>
               <clip>
                   <near>0.02</near>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

change the colour space of the simulated gazebo camera from RGB8 to BGR8, as is expected by the standard for pointclouds (and more generally).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #21 

## QA Instructions, Screenshots, Recordings

With this in place, RViz2 shows the correct red and blue colours  both in image view and in pointcloud:

<img width="808" alt="image" src="https://github.com/LCAS/limo_ros2/assets/1153084/880e9189-d63b-4e46-8c6c-63a8eaf9339a">





## [optional] Are there any post deployment tasks we need to perform?

rebuild and deploy the https://github.com/LCAS/teaching image when this is fixed.