### PR TITLE
gazebo exec dependency added

### DIFF
--- a/src/limo_gazebosim/package.xml
+++ b/src/limo_gazebosim/package.xml
@@ -13,6 +13,8 @@
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
 
+  <exec_depend>gazebo_ros</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Adds exec dependency to the limo_gazebosim package

## What type of PR is this? (check all applicable)

- [ X] Bug Fix

