### PR TITLE
update QoS settings for image and point cloud publishers

### DIFF
--- a/src/ros2_astra_camera/astra_camera/src/ob_camera_node.cpp
+++ b/src/ros2_astra_camera/astra_camera/src/ob_camera_node.cpp
@@ -300,7 +300,7 @@ void OBCameraNode::setupPublishers() {
       std::string name = stream_name_[stream_index];
       std::string topic = name + "/image_raw";
       image_publishers_[stream_index] =
-          image_transport::create_publisher(node_, topic, rmw_qos_profile_sensor_data);
+          image_transport::create_publisher(node_, topic, rmw_qos_profile_default);
       topic = name + "/camera_info";
       camera_info_publishers_[stream_index] =
           node_->create_publisher<CameraInfo>(topic, rclcpp::QoS{1}.best_effort());

--- a/src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyz.cpp
+++ b/src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyz.cpp
@@ -52,7 +52,7 @@ PointCloudXyzNode::PointCloudXyzNode(const rclcpp::NodeOptions &options)
   // Make sure we don't enter connectCb() between advertising and assigning to pub_point_cloud_
   std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement when SubscriberStatusCallback is available
-  pub_point_cloud_ = create_publisher<PointCloud2>("depth/points", rclcpp::SensorDataQoS());
+  pub_point_cloud_ = create_publisher<PointCloud2>("depth/points", rclcpp::SystemDefaultsQoS());
 }
 
 template <typename T>

--- a/src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyzrgb.cpp
+++ b/src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyzrgb.cpp
@@ -76,7 +76,7 @@ PointCloudXyzrgbNode::PointCloudXyzrgbNode(const rclcpp::NodeOptions& options)
   // Make sure we don't enter connectCb() between advertising and assigning to pub_point_cloud_
   std::lock_guard<std::mutex> lock(connect_mutex_);
   // TODO(ros2) Implement connect_cb when SubscriberStatusCallback is available
-  pub_point_cloud_ = create_publisher<PointCloud2>("depth/color/points", rclcpp::SensorDataQoS());
+  pub_point_cloud_ = create_publisher<PointCloud2>("depth/color/points", rclcpp::SystemDefaultsQoS());
   // TODO(ros2) Implement connect_cb when SubscriberStatusCallback is available
 }
 

--- a/src/ros2_astra_camera/astra_camera/src/uvc_camera_driver.cpp
+++ b/src/ros2_astra_camera/astra_camera/src/uvc_camera_driver.cpp
@@ -70,7 +70,7 @@ UVCCameraDriver::UVCCameraDriver(rclcpp::Node* node, std::shared_ptr<Parameters>
   config_.optical_frame_id = camera_name_ + "_color_optical_frame";
   setupCameraControlService();
   image_publisher_ =
-      image_transport::create_publisher(node_, "color/image_raw", rmw_qos_profile_sensor_data);
+      image_transport::create_publisher(node_, "color/image_raw", rmw_qos_profile_default);
   camera_info_publisher_ = node_->create_publisher<sensor_msgs::msg::CameraInfo>(
       "color/camera_info", rclcpp::QoS{1}.best_effort());
   openCamera();

--- a/src/ydlidar_ros2/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2/src/ydlidar_ros2_driver_node.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
     RCLCPP_ERROR(node->get_logger(), "%s\n", laser.DescribeError());
   }
   
-  auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
+  auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
 
   auto stop_scan_service =
     [&laser](const std::shared_ptr<rmw_request_id_t> /* request_header */,


### PR DESCRIPTION
This pull request includes changes to the `ros2_astra_camera` package to update the QoS (Quality of Service) profiles used for various publishers. The most important changes involve switching from `rmw_qos_profile_sensor_data` to `rmw_qos_profile_default` and from `rclcpp::SensorDataQoS()` to `rclcpp::SystemDefaultsQoS()`.

Updates to QoS profiles:

* [`src/ros2_astra_camera/astra_camera/src/ob_camera_node.cpp`](diffhunk://#diff-eb0187d51345c491f1f008b14ba4e5d6535d4ad3caf0ea5b1ab8b8502d3b769aL303-R303): Changed the QoS profile for image publishers from `rmw_qos_profile_sensor_data` to `rmw_qos_profile_default`.
* [`src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyz.cpp`](diffhunk://#diff-75a725a1ece20b3fc7bba258fdb7d86c4db05f9d7c6f76a33c4da1868ffaab85L55-R55): Updated the QoS profile for the point cloud publisher from `rclcpp::SensorDataQoS()` to `rclcpp::SystemDefaultsQoS()`.
* [`src/ros2_astra_camera/astra_camera/src/point_cloud_proc/point_cloud_xyzrgb.cpp`](diffhunk://#diff-a0943721d3e2cb41675df61cf867ed14b3fbca2e2eb30b3a063c018fc499a78eL79-R79): Modified the QoS profile for the point cloud publisher from `rclcpp::SensorDataQoS()` to `rclcpp::SystemDefaultsQoS()`.
* [`src/ros2_astra_camera/astra_camera/src/uvc_camera_driver.cpp`](diffhunk://#diff-91413eabb60314c4d197915fc479fa9c890885561e511007f7fd705673c8c400L73-R73): Changed the QoS profile for the image publisher from `rmw_qos_profile_sensor_data` to `rmw_qos_profile_default`.